### PR TITLE
Change mysql-server to mariadb-server

### DIFF
--- a/raspisms/DEBIAN/control
+++ b/raspisms/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 2.0
 Section: base
 Priority: optional
 Architecture: all
-Depends: apache2, php, php-mysql, php-mbstring, gammu, mysql-server
+Depends: apache2, php, php-mysql, php-mbstring, gammu, mariadb-server
 Maintainer: Raspbian France <raspbianfrance@gmail.com>
 Description: Web application for SMS management, sends, planning, order receipt. And providing API.
 Homepage: http://raspbian-france.fr


### PR DESCRIPTION
The dependency `mysql-server` is now deprecated so we need to use `mariadb-server` instead.

---

La dépendance `mysql-server` est maintenant dépréciée, on doit donc utiliser `mariadb-server` à la place.
